### PR TITLE
Issue 6: Add legacy data migration to ProgramData

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
 
     <!-- Full internal packaged build version -->
-    <FileVersion>1.1.0.28</FileVersion>
+    <FileVersion>1.1.0.30</FileVersion>
 
     <!-- Public version plus internal build metadata -->
-    <InformationalVersion>1.1.0+build.28</InformationalVersion>
+    <InformationalVersion>1.1.0+build.30</InformationalVersion>
   </PropertyGroup>
 </Project>

--- a/src/OrchidApp.Launcher/Infrastructure/LegacyDataMigrationService.cs
+++ b/src/OrchidApp.Launcher/Infrastructure/LegacyDataMigrationService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace OrchidApp.Launcher.Infrastructure;
+
+internal sealed class LegacyDataMigrationService
+{
+    private readonly WindowsProgramDataPaths _programDataPaths;
+
+    public LegacyDataMigrationService(WindowsProgramDataPaths programDataPaths)
+    {
+        _programDataPaths = programDataPaths;
+    }
+
+    public void MigrateFromLegacyRoot(string legacyRootPath)
+    {
+        if (string.IsNullOrWhiteSpace(legacyRootPath))
+        {
+            throw new InvalidOperationException("Legacy root path was not provided.");
+        }
+
+        var legacyMariaDbPath = Path.Combine(legacyRootPath, "data", "mariadb");
+        var legacyUploadsPath = Path.Combine(legacyRootPath, "wwwroot", "uploads");
+        var legacySettingsPath = Path.Combine(legacyRootPath, "launcher-settings.json");
+
+        ValidateLegacySource(legacyMariaDbPath);
+        ValidateProgramDataTargetIsSafe();
+
+        CopyDirectory(legacyMariaDbPath, _programDataPaths.MariaDbData);
+
+        if (Directory.Exists(legacyUploadsPath))
+        {
+            CopyDirectory(legacyUploadsPath, _programDataPaths.Uploads);
+        }
+
+        if (File.Exists(legacySettingsPath))
+        {
+            File.Copy(legacySettingsPath, _programDataPaths.LauncherSettingsFile, overwrite: false);
+        }
+    }
+
+    private static void ValidateLegacySource(string legacyMariaDbPath)
+    {
+        var legacyOrchidsDatabasePath = Path.Combine(legacyMariaDbPath, "orchids");
+
+        if (!Directory.Exists(legacyOrchidsDatabasePath))
+        {
+            throw new InvalidOperationException(
+                "Legacy migration source is invalid because it does not contain data\\mariadb\\orchids.");
+        }
+
+        if (!Directory.EnumerateFileSystemEntries(legacyOrchidsDatabasePath).Any())
+        {
+            throw new InvalidOperationException(
+                "Legacy migration source is invalid because data\\mariadb\\orchids is empty.");
+        }
+    }
+
+    private void ValidateProgramDataTargetIsSafe()
+    {
+        var targetOrchidsDatabasePath = Path.Combine(_programDataPaths.MariaDbData, "orchids");
+
+        if (Directory.Exists(targetOrchidsDatabasePath) &&
+            Directory.EnumerateFileSystemEntries(targetOrchidsDatabasePath).Any())
+        {
+            throw new InvalidOperationException(
+                "ProgramData already contains an orchids database. Migration has been stopped to avoid overwriting user data.");
+        }
+
+        if (Directory.Exists(_programDataPaths.Uploads) &&
+            Directory.EnumerateFileSystemEntries(_programDataPaths.Uploads).Any())
+        {
+            throw new InvalidOperationException(
+                "ProgramData uploads folder already contains files. Migration has been stopped to avoid overwriting user uploads.");
+        }
+
+        if (File.Exists(_programDataPaths.LauncherSettingsFile))
+        {
+            throw new InvalidOperationException(
+                "ProgramData launcher settings already exist. Migration has been stopped to avoid overwriting user settings.");
+        }
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string targetDirectory)
+    {
+        Directory.CreateDirectory(targetDirectory);
+
+        foreach (var sourcePath in Directory.EnumerateFileSystemEntries(
+                     sourceDirectory,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, sourcePath);
+            var targetPath = Path.Combine(targetDirectory, relativePath);
+
+            if (Directory.Exists(sourcePath))
+            {
+                Directory.CreateDirectory(targetPath);
+                continue;
+            }
+
+            var targetParentDirectory = Path.GetDirectoryName(targetPath);
+
+            if (!string.IsNullOrWhiteSpace(targetParentDirectory))
+            {
+                Directory.CreateDirectory(targetParentDirectory);
+            }
+
+            File.Copy(sourcePath, targetPath, overwrite: false);
+        }
+    }
+}

--- a/src/OrchidApp.Launcher/OrchidAppLauncherForm.cs
+++ b/src/OrchidApp.Launcher/OrchidAppLauncherForm.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Reflection;
+using System.Linq;
 using MySqlConnector;
 using OrchidApp.Launcher.Infrastructure;
 
@@ -58,7 +59,9 @@ public partial class OrchidAppLauncherForm : Form
     private string? _webAppStartupError;
 
     private readonly object _logLock = new object();
-
+    
+    private readonly WindowsProgramDataPaths _programDataPaths = new();
+    
     private readonly string _logFilePath =
         Path.Combine(AppContext.BaseDirectory, "launcher.log");
 
@@ -172,10 +175,9 @@ public partial class OrchidAppLauncherForm : Form
         {
             SetLauncherStatus(LauncherStatus.Red);
 
-            var programDataPaths = new WindowsProgramDataPaths();
-
-            var programDataDirectoryService =
-                new WindowsProgramDataDirectoryService(programDataPaths, AppendLog);
+            var programDataDirectoryService = new WindowsProgramDataDirectoryService(
+                _programDataPaths,
+                AppendLog);
 
             programDataDirectoryService.EnsureRequiredDirectoriesExist();
 
@@ -215,6 +217,15 @@ public partial class OrchidAppLauncherForm : Form
 
                 _preUpgradeBackupCompletedThisStartup = true;
                 AppendLog("Pre-upgrade backup succeeded. Startup may continue.");
+            
+                AppendLog("Starting legacy data migration to ProgramData...");
+
+                var legacyCandidate = layout.LegacyCandidates.Single(candidate => candidate.HasOrchidsDatabase);
+
+                var migrationService = new LegacyDataMigrationService(_programDataPaths);
+                migrationService.MigrateFromLegacyRoot(legacyCandidate.RootPath);
+
+                AppendLog("Legacy data migration to ProgramData completed.");
             }
 
             StartMariaDb();


### PR DESCRIPTION
Issue 6 copies legacy data into ProgramData after a successful mandatory pre-upgrade backup. It does not switch MariaDB or upload runtime paths to ProgramData. Runtime path switching remains Issue 8.