### PR TITLE
Complete clean first install ProgramData layout

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
 
     <!-- Full internal packaged build version -->
-    <FileVersion>1.1.0.56</FileVersion>
+    <FileVersion>1.1.0.61</FileVersion>
 
     <!-- Public version plus internal build metadata -->
-    <InformationalVersion>1.1.0+build.56</InformationalVersion>
+    <InformationalVersion>1.1.0+build.61</InformationalVersion>
   </PropertyGroup>
 </Project>

--- a/app/tools/backup-orchidapp.ps1
+++ b/app/tools/backup-orchidapp.ps1
@@ -162,7 +162,7 @@ $BackupLogPath = Join-Path $BackupWorkingRoot "backup.log"
 $MariaDbServerLogPath = Join-Path $BackupWorkingRoot "mariadb-server.log"
 $MariaDbServerErrorLogPath = Join-Path $BackupWorkingRoot "mariadb-server-error.log"
 $BackupZip = Join-Path $BackupsRoot "$BackupName.zip"
-$MariaDbDataRoot = Join-Path $AppRoot "data\mariadb"
+$MariaDbDataRoot = $MariaDbData
 
 $StartedMariaDb = $false
 $MariaDbProcess = $null

--- a/src/OrchidApp.Launcher/LauncherSettingsService.cs
+++ b/src/OrchidApp.Launcher/LauncherSettingsService.cs
@@ -4,8 +4,6 @@ namespace OrchidApp.Launcher;
 
 public sealed class LauncherSettingsService
 {
-    private const string SettingsFileName = "launcher-settings.json";
-
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
         WriteIndented = true
@@ -13,11 +11,14 @@ public sealed class LauncherSettingsService
 
     public string SettingsFilePath { get; }
 
-    public LauncherSettingsService()
+    public LauncherSettingsService(string settingsFilePath)
     {
-        SettingsFilePath = Path.Combine(
-            AppContext.BaseDirectory,
-            SettingsFileName);
+        if (string.IsNullOrWhiteSpace(settingsFilePath))
+        {
+            throw new ArgumentException("Settings file path must be provided.", nameof(settingsFilePath));
+        }
+
+        SettingsFilePath = settingsFilePath;
     }
 
     public LauncherSettings Load()
@@ -40,6 +41,13 @@ public sealed class LauncherSettingsService
 
     public void Save(LauncherSettings settings)
     {
+        var settingsDirectory = Path.GetDirectoryName(SettingsFilePath);
+
+        if (!string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            Directory.CreateDirectory(settingsDirectory);
+        }
+
         var json = JsonSerializer.Serialize(settings, _jsonOptions);
 
         File.WriteAllText(SettingsFilePath, json);

--- a/src/OrchidApp.Launcher/OrchidAppLauncherForm.cs
+++ b/src/OrchidApp.Launcher/OrchidAppLauncherForm.cs
@@ -669,18 +669,24 @@ FLUSH PRIVILEGES;
 
         var exePath = Path.Combine(baseDir, "OrchidApp.Web.exe");
 
+        var webAppStartInfo = new ProcessStartInfo
+        {
+            FileName = exePath,
+            Arguments = "--urls=http://localhost:5285",
+            WorkingDirectory = baseDir,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        webAppStartInfo.Environment["ORCHIDAPP_UPLOAD_ROOT"] = _programDataPaths.Uploads;
+
+        AppendLog($"Web upload root: {_programDataPaths.Uploads}");
+
         _webAppProcess = new Process
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = exePath,
-                Arguments = "--urls=http://localhost:5285",
-                WorkingDirectory = baseDir,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            }
+            StartInfo = webAppStartInfo
         };
 
         _webAppProcess.EnableRaisingEvents = true;
@@ -1228,13 +1234,11 @@ FLUSH PRIVILEGES;
 
     private FileInfo? GetLatestBackupFile()
     {
-        var backupsDir = Path.Combine(
-            AppContext.BaseDirectory,
-            "backups"
-        );
+        var backupsDir = _programDataPaths.Backups;
 
         if (!Directory.Exists(backupsDir))
         {
+            AppendLog($"Backup folder does not exist: {backupsDir}");
             return null;
         }
 
@@ -1246,7 +1250,7 @@ FLUSH PRIVILEGES;
 
     private void CopyLatestBackupToCloudFolder()
     {
-        var settingsService = new LauncherSettingsService();
+        var settingsService = new LauncherSettingsService(_programDataPaths.LauncherSettingsFile);
         var settings = settingsService.Load();
 
         if (string.IsNullOrWhiteSpace(settings.CloudBackupFolderPath))
@@ -1311,7 +1315,7 @@ FLUSH PRIVILEGES;
 
     private void ConfigureCloudBackupButton_Click(object? sender, EventArgs e)
     {
-        var settingsService = new LauncherSettingsService();
+        var settingsService = new LauncherSettingsService(_programDataPaths.LauncherSettingsFile);
         var settings = settingsService.Load();
 
         using var dialog = new FolderBrowserDialog

--- a/src/OrchidApp.Web/Program.cs
+++ b/src/OrchidApp.Web/Program.cs
@@ -18,17 +18,26 @@ Console.WriteLine($"ENV: {builder.Environment.EnvironmentName}");
 
 if (builder.Environment.IsEnvironment("Desktop"))
 {
-    var desktopUploadsRoot = Path.Combine(
-        AppContext.BaseDirectory,
-        "wwwroot",
-        "uploads"
-    );
+    var uploadRootFromEnvironment =
+        Environment.GetEnvironmentVariable("ORCHIDAPP_UPLOAD_ROOT");
+
+    var desktopUploadsRoot = !string.IsNullOrWhiteSpace(uploadRootFromEnvironment)
+        ? uploadRootFromEnvironment
+        : Path.Combine(
+            AppContext.BaseDirectory,
+            "wwwroot",
+            "uploads"
+        );
 
     Directory.CreateDirectory(desktopUploadsRoot);
 
     builder.Configuration["Storage:UploadRoot"] = desktopUploadsRoot;
 
-    Console.WriteLine($"Desktop UploadRoot: {desktopUploadsRoot}");
+    Console.WriteLine(
+        !string.IsNullOrWhiteSpace(uploadRootFromEnvironment)
+            ? $"Desktop UploadRoot: {desktopUploadsRoot} Source: Environment"
+            : $"Desktop UploadRoot: {desktopUploadsRoot} Source: AppContext fallback"
+    );
 }
 
 // Add services to the container.


### PR DESCRIPTION
Issue 9 complete.

Clean Windows first install now uses ProgramData as the mutable user-data root. OrchidApp.Web receives the upload root from the launcher using ORCHIDAPP_UPLOAD_ROOT and stores uploads under C:\ProgramData\OrchidApp\uploads. Launcher settings now read/write C:\ProgramData\OrchidApp\launcher-settings.json instead of the app root. Normal backups use ProgramData data/uploads/settings and write to C:\ProgramData\OrchidApp\backups. Cloud latest-backup copy now finds the latest ProgramData normal backup and creates OrchidAppDataBackup.zip in the configured cloud folder.

Tested clean install, restart persistence, manual backup, backup manifest paths, cloud backup copy and confirmed no live user data is written to the app root.