### PR TITLE
Add environment 7-day summary model and UI

### DIFF
--- a/src/OrchidApp.Web/Data/OrchidDbContext.cs
+++ b/src/OrchidApp.Web/Data/OrchidDbContext.cs
@@ -28,6 +28,7 @@ public class OrchidDbContext : DbContext
     public DbSet<GrowthMedium> GrowthMedia =>                               Set<GrowthMedium>();
     public DbSet<Repotting> Repotting =>                                    Set<Repotting>();
     public DbSet<PlantCurrentGrowthMedium> PlantCurrentGrowthMedium =>      Set<PlantCurrentGrowthMedium>();
+    public DbSet<EnvironmentLastSevenDaysSummary> EnvironmentLastSevenDaysSummaries { get; set; }
     public DbSet<Location> Locations { get; set; } = null!;
     public DbSet<PlantPhoto> PlantPhotos { get; set; }
     public DbSet<ObservationType> ObservationTypes { get; set; }
@@ -420,6 +421,40 @@ public class OrchidDbContext : DbContext
         modelBuilder.Entity<AddPlantResult>().HasNoKey();
         modelBuilder.Entity<PropagationTypeLookup>().HasNoKey();
         modelBuilder.Entity<PlantChildLink>().HasNoKey();
-        
+        modelBuilder.Entity<EnvironmentLastSevenDaysSummary>(entity =>
+        {
+            entity.HasNoKey();
+            entity.ToView("venvironmentlastsevendayssummary");
+
+            entity.Property(e => e.LocationName)
+                .HasColumnName("locationName");
+
+            entity.Property(e => e.AverageDayTemperatureCelsius)
+                .HasColumnName("averageDayTemperatureCelsius");
+
+            entity.Property(e => e.ExpectedDayTemperatureCelsius)
+                .HasColumnName("expectedDayTemperatureCelsius");
+
+            entity.Property(e => e.AverageNightTemperatureCelsius)
+                .HasColumnName("averageNightTemperatureCelsius");
+
+            entity.Property(e => e.ExpectedNightTemperatureCelsius)
+                .HasColumnName("expectedNightTemperatureCelsius");
+
+            entity.Property(e => e.AverageRelativeHumidity)
+                .HasColumnName("averageRelativeHumidity");
+
+            entity.Property(e => e.ExpectedRelativeHumidity)
+                .HasColumnName("expectedRelativeHumidity");
+
+            entity.Property(e => e.ReadingCount)
+                .HasColumnName("readingCount");
+
+            entity.Property(e => e.FirstReadingDateTime)
+                .HasColumnName("firstReadingDateTime");
+
+            entity.Property(e => e.LastReadingDateTime)
+                .HasColumnName("lastReadingDateTime");
+        });
     }
 }

--- a/src/OrchidApp.Web/Models/EnvironmentLastSevenDaysSummary.cs
+++ b/src/OrchidApp.Web/Models/EnvironmentLastSevenDaysSummary.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace OrchidApp.Web.Models;
+
+public class EnvironmentLastSevenDaysSummary
+{
+    public string LocationName { get; set; } = string.Empty;
+
+    public decimal? AverageDayTemperatureCelsius { get; set; }
+    public decimal ExpectedDayTemperatureCelsius { get; set; }
+
+    public decimal? AverageNightTemperatureCelsius { get; set; }
+    public decimal ExpectedNightTemperatureCelsius { get; set; }
+
+    public decimal? AverageRelativeHumidity { get; set; }
+    public decimal ExpectedRelativeHumidity { get; set; }
+
+    public long ReadingCount { get; set; }
+
+    public DateTime? FirstReadingDateTime { get; set; }
+    public DateTime? LastReadingDateTime { get; set; }
+}

--- a/src/OrchidApp.Web/Pages/Index.cshtml
+++ b/src/OrchidApp.Web/Pages/Index.cshtml
@@ -7,6 +7,68 @@
     Manage your orchid collection and care history.
 </p>
 
+@if (Model.EnvironmentSummaries.Any())
+{
+    <section class="mb-4">
+        <h2 class="h5 fw-bold mb-3">Environment - last 7 days</h2>
+
+        <div class="row g-3">
+            @foreach (var summary in Model.EnvironmentSummaries)
+            {
+                <div class="col-12 col-md-6">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h3 class="h6 fw-bold mb-3">@summary.LocationName</h3>
+
+                            <dl class="row mb-0">
+                                <dt class="col-7">Day temperature</dt>
+                                <dd class="col-5 text-end">
+                                    @FormatValue(summary.AverageDayTemperatureCelsius, "°C")
+                                    <span class="text-muted">
+                                        / @summary.ExpectedDayTemperatureCelsius.ToString("0.0")°C
+                                    </span>
+                                </dd>
+
+                                <dt class="col-7">Night temperature</dt>
+                                <dd class="col-5 text-end">
+                                    @FormatValue(summary.AverageNightTemperatureCelsius, "°C")
+                                    <span class="text-muted">
+                                        / @summary.ExpectedNightTemperatureCelsius.ToString("0.0")°C
+                                    </span>
+                                </dd>
+
+                                <dt class="col-7">Humidity</dt>
+                                <dd class="col-5 text-end">
+                                    @FormatValue(summary.AverageRelativeHumidity, "%")
+                                    <span class="text-muted">
+                                        / @summary.ExpectedRelativeHumidity.ToString("0.0")%
+                                    </span>
+                                </dd>
+                            </dl>
+
+                            @if (summary.LastReadingDateTime.HasValue)
+                            {
+                                <p class="small text-muted mb-0 mt-3">
+                                    Last reading: @summary.LastReadingDateTime.Value.ToString("dd MMM yyyy HH:mm")
+                                </p>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </section>
+}
+
+@functions {
+    private static string FormatValue(decimal? value, string suffix)
+    {
+        return value.HasValue
+            ? $"{value.Value:0.0}{suffix}"
+            : "-";
+    }
+}
+
 <div class="d-grid gap-3 mt-4">
 
     <a asp-page="/Plants/Index"

--- a/src/OrchidApp.Web/Pages/Index.cshtml.cs
+++ b/src/OrchidApp.Web/Pages/Index.cshtml.cs
@@ -1,11 +1,26 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using OrchidApp.Web.Data;
+using OrchidApp.Web.Models;
 
-namespace OrchidApp.Web.Pages
+namespace OrchidApp.Web.Pages;
+
+public class IndexModel : PageModel
 {
-    public class IndexModel : PageModel
+    private readonly OrchidDbContext _context;
+
+    public IndexModel(OrchidDbContext context)
     {
-        public void OnGet()
-        {
-        }
+        _context = context;
+    }
+
+    public IReadOnlyList<EnvironmentLastSevenDaysSummary> EnvironmentSummaries { get; private set; }
+        = [];
+
+    public async Task OnGetAsync()
+    {
+        EnvironmentSummaries = await _context.EnvironmentLastSevenDaysSummaries
+            .OrderBy(summary => summary.LocationName)
+            .ToListAsync();
     }
 }


### PR DESCRIPTION
Introduce EnvironmentLastSevenDaysSummary model and surface it on the home page. Register a DbSet in OrchidDbContext and configure the entity as a keyless mapping to the database view (venvironmentlastsevendayssummary) with property column mappings. Inject OrchidDbContext into the Index page model and asynchronously load ordered summaries, and update Index.cshtml to render per-location metrics (day/night temperatures, humidity, reading counts and last reading) with simple formatting.